### PR TITLE
Process mail without matching attachments

### DIFF
--- a/scripts/processmail.sh
+++ b/scripts/processmail.sh
@@ -43,16 +43,14 @@ then
   # for each new received e-mail
   for file in ${NEWMAILDIR}/*
   do
+    # extract short message
+    shortmessage=`mu view "${file}" | grep "^Subject" | sed 's/Subject: \(.*\)$/\1/'`
+    # Escape double quotes
+    shortmessage="${shortmessage//\"/\\\"}"
+    echo "Subject: $shortmessage" >&2
     # extract supported attachments
-    mu extract  --overwrite --target-dir=${TMPPROCDIR} "${file}" '.*(\.jpg|\.jpeg|\.png|\.mov|\.mp4)'
-    # if attachments extracted successfully and tmp processing directory is not empty
-    if [ $? -eq 0 -a ! -z "$(ls -A $TMPPROCDIR)" ] ;
+    if mu extract  --overwrite --target-dir=${TMPPROCDIR} "${file}" '.*(\.jpg|\.jpeg|\.png|\.mov|\.mp4)'
     then
-      # extract short message
-      shortmessage=`mu view "${file}" | grep "^Subject" | sed 's/Subject: \(.*\)$/\1/'`
-      # Escape double quotes
-      shortmessage="${shortmessage//\"/\\\"}"
-
       # process all attachments, move all attachments to livetracks dir with timestamp filename 
       for attach in ${TMPPROCDIR}/*
       do
@@ -71,8 +69,8 @@ then
         fi
         echo "${medianame}: \"${shortmessage}\"" >> ${MEDIAMETA}.TMP
       done
+      rm -f "${file}"
      fi
-     rm -f $file
   done
 
   status="${status} success ${imgcount} new images retrieved"


### PR DESCRIPTION
Previously, if a message did not contain attachments, the program would crash due to set -e. The status of the command did not get evaluated. This commit adds set -e compatibility of the `mu extract` command and only deletes messages that were processed, leaving unprocessed messages in the mailbox for later processing if other image formats or message processing is supported.