### PR TITLE
Do not remove UTF-8 from Mail Subject

### DIFF
--- a/scripts/init_raspbian.sh
+++ b/scripts/init_raspbian.sh
@@ -32,6 +32,7 @@ echo
 read -p "install required packages [y/N] " prompt
 if test "$prompt" == "y"; then
   apt install -y \
+    fonts-noto-color-emoji \
     getmail \
     git \
     imagemagick \

--- a/scripts/processmail.sh
+++ b/scripts/processmail.sh
@@ -17,9 +17,6 @@ MAXPCTUSG=95
 APPLEMOVEXT="*mov*"
 IMGLIST="*jpg*jpeg*png*"
 
-LANG=
-LANGUAGE=
-LC_CTYPE="POSIX"
 # create files/folders if not exists
 if [ ! -e ${MEDIAMETA} ]; then
   touch ${MEDIAMETA}
@@ -76,8 +73,6 @@ then
   status="${status} success ${imgcount} new images retrieved"
 
   cp --force ${MEDIAMETA}.TMP ${MEDIAMETA}
-  # Remove emoticons
-  sed -i 's/[\d128-\d255]//g' ${MEDIAMETA}
   if [ $imgcount -gt 0 ] ;
   then
     sudo systemctl restart lightdm.service

--- a/scripts/processmail.sh
+++ b/scripts/processmail.sh
@@ -17,6 +17,8 @@ MAXPCTUSG=95
 APPLEMOVEXT="*mov*"
 IMGLIST="*jpg*jpeg*png*"
 
+LC_CTYPE="POSIX"
+
 # create files/folders if not exists
 if [ ! -e ${MEDIAMETA} ]; then
   touch ${MEDIAMETA}


### PR DESCRIPTION
Support UTF-8 Characters by using the default system locale (which should be a en_US.UTF-8 or similar specification. Check with `locale` that the system is configured correctly and do not remove the variables in the script.